### PR TITLE
feat: extend 'Update from upstream first' to Same branch in New Copilot Session

### DIFF
--- a/src/Forms/MainForm.ContextMenu.cs
+++ b/src/Forms/MainForm.ContextMenu.cs
@@ -77,32 +77,42 @@ internal partial class MainForm
                     return;
                 }
 
+                // Update from upstream before creating the session
+                if (promptResult.UpdateSourceFirst)
+                {
+                    var gitRoot = SessionService.FindGitRoot(selectedCwd);
+                    if (gitRoot != null)
+                    {
+                        (bool updateOk, string? updateErr) = promptResult.Action switch
+                        {
+                            BranchAction.None =>
+                                await WorkspaceCreationService.PullCurrentBranchAsync(gitRoot, CancellationToken.None).ConfigureAwait(true),
+                            BranchAction.ExistingBranch when !string.IsNullOrEmpty(promptResult.BranchName) =>
+                                await UpdateAndDropEffectiveRefAsync(gitRoot, promptResult.BranchName).ConfigureAwait(true),
+                            BranchAction.NewBranch when !string.IsNullOrEmpty(promptResult.BaseBranch) =>
+                                await UpdateAndDropEffectiveRefAsync(gitRoot, promptResult.BaseBranch).ConfigureAwait(true),
+                            _ => (true, null)
+                        };
+
+                        if (!updateOk)
+                        {
+                            var proceed = MessageBox.Show(this,
+                                $"Couldn't update from upstream:\n{updateErr}\n\nCreate session anyway with current state?",
+                                "Update Failed", MessageBoxButtons.YesNo, MessageBoxIcon.Warning);
+                            if (proceed == DialogResult.No)
+                            {
+                                return;
+                            }
+                        }
+                    }
+                }
+
                 // Handle branch/PR checkout in the CWD before creating the session
                 if (promptResult.Action != BranchAction.None)
                 {
                     var gitRoot = SessionService.FindGitRoot(selectedCwd);
                     if (gitRoot != null)
                     {
-                        if (promptResult.UpdateSourceFirst &&
-                            (promptResult.Action == BranchAction.ExistingBranch || promptResult.Action == BranchAction.NewBranch))
-                        {
-                            var sourceRefForUpdate = promptResult.Action == BranchAction.ExistingBranch
-                                ? promptResult.BranchName!
-                                : promptResult.BaseBranch!;
-                            var (updateOk, updateErr, _) = await WorkspaceCreationService.UpdateSourceBranchAsync(
-                                selectedCwd, sourceRefForUpdate, CancellationToken.None).ConfigureAwait(true);
-                            if (!updateOk)
-                            {
-                                var proceed = MessageBox.Show(this,
-                                    $"Couldn't update from upstream:\n{updateErr}\n\nCreate session anyway with current state?",
-                                    "Update Failed", MessageBoxButtons.YesNo, MessageBoxIcon.Warning);
-                                if (proceed == DialogResult.No)
-                                {
-                                    return;
-                                }
-                            }
-                        }
-
                         (bool success, string error) checkoutResult = promptResult.Action switch
                         {
                             BranchAction.ExistingBranch when !string.IsNullOrEmpty(promptResult.BranchName) =>

--- a/src/Forms/MainForm.cs
+++ b/src/Forms/MainForm.cs
@@ -270,6 +270,13 @@ internal partial class MainForm : Form
         }
     }
 
+    private static async Task<(bool updateOk, string? updateErr)> UpdateAndDropEffectiveRefAsync(string gitRoot, string sourceRef)
+    {
+        var (updateOk, updateErr, _) = await WorkspaceCreationService.UpdateSourceBranchAsync(
+            gitRoot, sourceRef, CancellationToken.None).ConfigureAwait(true);
+        return (updateOk, updateErr);
+    }
+
     private void SetupTrayIcon()
     {
         var trayMenu = new ContextMenuStrip();
@@ -2037,32 +2044,42 @@ internal partial class MainForm : Form
                 return;
             }
 
+            // Update from upstream before creating the session
+            if (promptResult.UpdateSourceFirst)
+            {
+                var gitRoot = SessionService.FindGitRoot(selectedCwd);
+                if (gitRoot != null)
+                {
+                    (bool updateOk, string? updateErr) = promptResult.Action switch
+                    {
+                        BranchAction.None =>
+                            await WorkspaceCreationService.PullCurrentBranchAsync(gitRoot, CancellationToken.None).ConfigureAwait(true),
+                        BranchAction.ExistingBranch when !string.IsNullOrEmpty(promptResult.BranchName) =>
+                            await UpdateAndDropEffectiveRefAsync(gitRoot, promptResult.BranchName).ConfigureAwait(true),
+                        BranchAction.NewBranch when !string.IsNullOrEmpty(promptResult.BaseBranch) =>
+                            await UpdateAndDropEffectiveRefAsync(gitRoot, promptResult.BaseBranch).ConfigureAwait(true),
+                        _ => (true, null)
+                    };
+
+                    if (!updateOk)
+                    {
+                        var proceed = MessageBox.Show(this,
+                            $"Couldn't update from upstream:\n{updateErr}\n\nCreate session anyway with current state?",
+                            "Update Failed", MessageBoxButtons.YesNo, MessageBoxIcon.Warning);
+                        if (proceed == DialogResult.No)
+                        {
+                            return;
+                        }
+                    }
+                }
+            }
+
             // Handle branch/PR/issue checkout before creating the session
             if (promptResult.Action != BranchAction.None)
             {
                 var gitRoot = SessionService.FindGitRoot(selectedCwd);
                 if (gitRoot != null)
                 {
-                    if (promptResult.UpdateSourceFirst &&
-                        (promptResult.Action == BranchAction.ExistingBranch || promptResult.Action == BranchAction.NewBranch))
-                    {
-                        var sourceRefForUpdate = promptResult.Action == BranchAction.ExistingBranch
-                            ? promptResult.BranchName!
-                            : promptResult.BaseBranch!;
-                        var (updateOk, updateErr, _) = await WorkspaceCreationService.UpdateSourceBranchAsync(
-                            selectedCwd, sourceRefForUpdate, CancellationToken.None).ConfigureAwait(true);
-                        if (!updateOk)
-                        {
-                            var proceed = MessageBox.Show(this,
-                                $"Couldn't update from upstream:\n{updateErr}\n\nCreate session anyway with current state?",
-                                "Update Failed", MessageBoxButtons.YesNo, MessageBoxIcon.Warning);
-                            if (proceed == DialogResult.No)
-                            {
-                                return;
-                            }
-                        }
-                    }
-
                     (bool success, string error) checkoutResult = promptResult.Action switch
                     {
                         BranchAction.ExistingBranch when !string.IsNullOrEmpty(promptResult.BranchName) =>

--- a/src/Forms/NewSessionNameVisuals.cs
+++ b/src/Forms/NewSessionNameVisuals.cs
@@ -749,7 +749,7 @@ internal static class NewSessionNameVisuals
             bool isPrMode = rdoFromPr.Checked;
             bool isIssueMode = rdoFromIssue.Checked;
             bool isSameBranch = rdoSameBranch.Checked;
-            bool showUpdateSource = isSwitchBranch || isNewBranch;
+            bool showUpdateSource = isSwitchBranch || isNewBranch || isSameBranch;
 
             // Current branch label — only visible in Same Branch mode
             lblCurrentBranch.Visible = isSameBranch;
@@ -932,12 +932,17 @@ internal static class NewSessionNameVisuals
             }
             else
             {
-                // Same branch — compact
-                btnOk.Location = new Point(300, cy);
-                btnCancel.Location = new Point(390, cy);
+                // Same branch
+                chkUpdateSource.Location = new Point(14, cy);
+                lblUpdateSourceHelper.Location = new Point(14, cy + 22);
+                cy += 46;
+
+                int buttonY = cy + 8;
+                btnOk.Location = new Point(300, buttonY);
+                btnCancel.Location = new Point(390, buttonY);
 
                 btnOk.Enabled = !string.IsNullOrWhiteSpace(txtSessionName.Text);
-                form.Height = cy + 70;
+                form.Height = buttonY + 70;
             }
         }
 
@@ -1352,7 +1357,7 @@ internal static class NewSessionNameVisuals
             }
             else
             {
-                result = new NewSessionResult(name, BranchAction.None, null, null, null, null, null, UpdateSourceFirst: false);
+                result = new NewSessionResult(name, BranchAction.None, null, null, null, null, null, UpdateSourceFirst: chkUpdateSource.Checked);
             }
 
             form.DialogResult = DialogResult.OK;

--- a/src/Services/GitService.cs
+++ b/src/Services/GitService.cs
@@ -550,6 +550,13 @@ internal static partial class GitService
         return exitCode == 0 ? (true, string.Empty) : (false, stderr.Trim());
     }
 
+    internal static async Task<(bool success, string? error)> PullFastForwardOnlyAsync(
+        string repoPath, CancellationToken cancellationToken = default)
+    {
+        var (exitCode, _, stderr) = await RunGitAsync(repoPath, "pull --ff-only", cancellationToken).ConfigureAwait(false);
+        return exitCode == 0 ? (true, null) : (false, stderr.Trim());
+    }
+
     internal static async Task<(FastForwardResult result, string error)> FetchAndFastForwardAsync(
         string repoPath, string remote, string localBranch, CancellationToken cancellationToken = default)
     {

--- a/src/Services/WorkspaceCreationService.cs
+++ b/src/Services/WorkspaceCreationService.cs
@@ -182,6 +182,27 @@ internal static class WorkspaceCreationService
             : (worktreePath, false, errorMsg);
     }
 
+    /// <summary>
+    /// Pulls the current branch using fast-forward-only semantics when it has an upstream.
+    /// If the current branch has no upstream, fetches the first configured remote, or <c>origin</c> when no remotes are configured.
+    /// </summary>
+    /// <returns><c>(true, null)</c> when the pull or fallback fetch succeeds; otherwise <c>(false, error)</c> with git stderr.</returns>
+    internal static async Task<(bool success, string? error)> PullCurrentBranchAsync(
+        string repoPath, CancellationToken cancellationToken = default)
+    {
+        var currentBranch = GitService.GetCurrentBranch(repoPath);
+        var upstreamRemote = GitService.GetUpstreamRemote(repoPath, currentBranch);
+        if (string.IsNullOrWhiteSpace(upstreamRemote))
+        {
+            var remotes = GitService.GetRemotes(repoPath);
+            var fallbackRemote = remotes.Count > 0 ? remotes[0] : "origin";
+            var (success, error) = await GitService.FetchRemoteAsync(repoPath, fallbackRemote, cancellationToken).ConfigureAwait(false);
+            return success ? (true, null) : (false, error);
+        }
+
+        return await GitService.PullFastForwardOnlyAsync(repoPath, cancellationToken).ConfigureAwait(false);
+    }
+
     internal static async Task<(bool success, string? error, string effectiveSourceRef)> UpdateSourceBranchAsync(
         string repoPath, string sourceRef, CancellationToken cancellationToken = default)
     {

--- a/tests/Integration/PullCurrentBranchOnSameBranchTests.cs
+++ b/tests/Integration/PullCurrentBranchOnSameBranchTests.cs
@@ -8,7 +8,7 @@ namespace CopilotBooster.IntegrationTests.Integration;
 public sealed class PullCurrentBranchOnSameBranchTests
 {
     [Fact]
-    public async Task SameBranchSession_UpdateEnabled_PullAdvancesWorkingTreeToRemoteTip()
+    public async Task PullCurrentBranchAsync_RealRepoWithRemote_AdvancesWorkingTreeHeadToRemoteTip()
     {
         using var repo = await GitTestRepo.CreateAsync(TestContext.Current.CancellationToken).ConfigureAwait(false);
         var remoteTip = await repo.CommitAndPushAsync("main", TestContext.Current.CancellationToken).ConfigureAwait(false);
@@ -21,7 +21,7 @@ public sealed class PullCurrentBranchOnSameBranchTests
     }
 
     [Fact]
-    public async Task SameBranchSession_UpdateEnabled_DirtyTree_PullFailsCleanly()
+    public async Task PullCurrentBranchAsync_DirtyTrackedFile_PullFailsAndHeadUnchanged()
     {
         using var repo = await GitTestRepo.CreateAsync(TestContext.Current.CancellationToken).ConfigureAwait(false);
         var localTip = await GitTestRepo.HeadAsync(repo.LocalPath, TestContext.Current.CancellationToken).ConfigureAwait(false);
@@ -33,21 +33,24 @@ public sealed class PullCurrentBranchOnSameBranchTests
         Assert.False(success);
         Assert.NotNull(error);
         Assert.NotEmpty(error);
+        Assert.Contains("overwritten", error, StringComparison.OrdinalIgnoreCase);
         Assert.Equal(localTip, await GitTestRepo.HeadAsync(repo.LocalPath, TestContext.Current.CancellationToken).ConfigureAwait(false));
     }
 
     [Fact]
-    public async Task SameBranchSession_UpdateEnabled_NoUpstream_FallsBackGracefully()
+    public async Task PullCurrentBranchAsync_NoUpstream_ReturnsSuccessFallbackFetch()
     {
         using var repo = await GitTestRepo.CreateAsync(TestContext.Current.CancellationToken).ConfigureAwait(false);
         var localTip = await repo.CreateLocalBranchWithoutUpstreamAsync("local-only", TestContext.Current.CancellationToken).ConfigureAwait(false);
         await repo.CheckoutAsync("local-only", TestContext.Current.CancellationToken).ConfigureAwait(false);
+        var remoteTip = await repo.CommitAndPushAsync("main", TestContext.Current.CancellationToken).ConfigureAwait(false);
 
         var (success, error) = await WorkspaceCreationService.PullCurrentBranchAsync(repo.LocalPath, TestContext.Current.CancellationToken).ConfigureAwait(false);
 
         Assert.True(success, error);
         Assert.Null(error);
         Assert.Equal(localTip, await GitTestRepo.HeadAsync(repo.LocalPath, TestContext.Current.CancellationToken).ConfigureAwait(false));
+        Assert.Equal(remoteTip, await GitTestRepo.RevParseAsync(repo.LocalPath, "origin/main", TestContext.Current.CancellationToken).ConfigureAwait(false));
     }
 
     private static async Task<string> CommitReadmeAndPushAsync(string repoPath, string branchName, CancellationToken cancellationToken)

--- a/tests/Integration/PullCurrentBranchOnSameBranchTests.cs
+++ b/tests/Integration/PullCurrentBranchOnSameBranchTests.cs
@@ -1,0 +1,70 @@
+﻿#pragma warning disable IDE1006
+
+using CopilotBooster.IntegrationTests.Integration.TestTools;
+
+namespace CopilotBooster.IntegrationTests.Integration;
+
+[Collection(GitIntegrationWorkspaceSettingsCollection.CollectionName)]
+public sealed class PullCurrentBranchOnSameBranchTests
+{
+    [Fact]
+    public async Task SameBranchSession_UpdateEnabled_PullAdvancesWorkingTreeToRemoteTip()
+    {
+        using var repo = await GitTestRepo.CreateAsync(TestContext.Current.CancellationToken).ConfigureAwait(false);
+        var remoteTip = await repo.CommitAndPushAsync("main", TestContext.Current.CancellationToken).ConfigureAwait(false);
+
+        var (success, error) = await WorkspaceCreationService.PullCurrentBranchAsync(repo.LocalPath, TestContext.Current.CancellationToken).ConfigureAwait(false);
+
+        Assert.True(success, error);
+        Assert.Null(error);
+        Assert.Equal(remoteTip, await GitTestRepo.HeadAsync(repo.LocalPath, TestContext.Current.CancellationToken).ConfigureAwait(false));
+    }
+
+    [Fact]
+    public async Task SameBranchSession_UpdateEnabled_DirtyTree_PullFailsCleanly()
+    {
+        using var repo = await GitTestRepo.CreateAsync(TestContext.Current.CancellationToken).ConfigureAwait(false);
+        var localTip = await GitTestRepo.HeadAsync(repo.LocalPath, TestContext.Current.CancellationToken).ConfigureAwait(false);
+        _ = await CommitReadmeAndPushAsync(repo.SourcePath, "main", TestContext.Current.CancellationToken).ConfigureAwait(false);
+        await File.AppendAllTextAsync(Path.Combine(repo.LocalPath, "README.md"), Environment.NewLine + "local dirty change", TestContext.Current.CancellationToken).ConfigureAwait(false);
+
+        var (success, error) = await WorkspaceCreationService.PullCurrentBranchAsync(repo.LocalPath, TestContext.Current.CancellationToken).ConfigureAwait(false);
+
+        Assert.False(success);
+        Assert.NotNull(error);
+        Assert.NotEmpty(error);
+        Assert.Equal(localTip, await GitTestRepo.HeadAsync(repo.LocalPath, TestContext.Current.CancellationToken).ConfigureAwait(false));
+    }
+
+    [Fact]
+    public async Task SameBranchSession_UpdateEnabled_NoUpstream_FallsBackGracefully()
+    {
+        using var repo = await GitTestRepo.CreateAsync(TestContext.Current.CancellationToken).ConfigureAwait(false);
+        var localTip = await repo.CreateLocalBranchWithoutUpstreamAsync("local-only", TestContext.Current.CancellationToken).ConfigureAwait(false);
+        await repo.CheckoutAsync("local-only", TestContext.Current.CancellationToken).ConfigureAwait(false);
+
+        var (success, error) = await WorkspaceCreationService.PullCurrentBranchAsync(repo.LocalPath, TestContext.Current.CancellationToken).ConfigureAwait(false);
+
+        Assert.True(success, error);
+        Assert.Null(error);
+        Assert.Equal(localTip, await GitTestRepo.HeadAsync(repo.LocalPath, TestContext.Current.CancellationToken).ConfigureAwait(false));
+    }
+
+    private static async Task<string> CommitReadmeAndPushAsync(string repoPath, string branchName, CancellationToken cancellationToken)
+    {
+        await RunGitAsync(repoPath, $"checkout {branchName}", cancellationToken).ConfigureAwait(false);
+        await File.AppendAllTextAsync(Path.Combine(repoPath, "README.md"), Environment.NewLine + Guid.NewGuid().ToString("N"), cancellationToken).ConfigureAwait(false);
+        await RunGitAsync(repoPath, "add README.md", cancellationToken).ConfigureAwait(false);
+        await RunGitAsync(repoPath, $"commit -m update-readme-{branchName}", cancellationToken).ConfigureAwait(false);
+        await RunGitAsync(repoPath, $"push origin {branchName}", cancellationToken).ConfigureAwait(false);
+        var tip = await GitTestRepo.RevParseAsync(repoPath, branchName, cancellationToken).ConfigureAwait(false);
+        await RunGitAsync(repoPath, "checkout main", cancellationToken).ConfigureAwait(false);
+        return tip;
+    }
+
+    private static async Task RunGitAsync(string repoPath, string arguments, CancellationToken cancellationToken)
+    {
+        var result = await GitService.RunGitAsync(repoPath, arguments, cancellationToken).ConfigureAwait(false);
+        Assert.True(result.exitCode == 0, $"git {arguments} failed in {repoPath}: {result.stderr}");
+    }
+}

--- a/tests/Services/GitServiceTests.cs
+++ b/tests/Services/GitServiceTests.cs
@@ -536,6 +536,82 @@ public sealed class GitServiceTests : IDisposable
         Assert.NotEmpty(error);
     }
 
+#pragma warning disable IDE1006
+
+    [Fact]
+    public async Task PullFastForwardOnlyAsync_RemoteAhead_ReturnsSuccessAndAdvancesHead()
+    {
+        var (sourcePath, repoPath) = this.CreateRemoteBackedRepo();
+        var expected = CommitAndPush(sourcePath, "main");
+
+        var (success, error) = await GitService.PullFastForwardOnlyAsync(repoPath, TestContext.Current.CancellationToken).ConfigureAwait(false);
+
+        Assert.True(success, error);
+        Assert.Null(error);
+        Assert.Equal(expected, RunGitOutput(repoPath, "rev-parse HEAD"));
+    }
+
+    [Fact]
+    public async Task PullFastForwardOnlyAsync_AlreadyUpToDate_ReturnsSuccess()
+    {
+        var (_, repoPath) = this.CreateRemoteBackedRepo();
+        var expected = RunGitOutput(repoPath, "rev-parse HEAD");
+
+        var (success, error) = await GitService.PullFastForwardOnlyAsync(repoPath, TestContext.Current.CancellationToken).ConfigureAwait(false);
+
+        Assert.True(success, error);
+        Assert.Null(error);
+        Assert.Equal(expected, RunGitOutput(repoPath, "rev-parse HEAD"));
+    }
+
+    [Fact]
+    public async Task PullFastForwardOnlyAsync_NonFastForward_ReturnsFailureWithError()
+    {
+        var (sourcePath, repoPath) = this.CreateRemoteBackedRepo();
+        File.WriteAllText(Path.Combine(repoPath, "local.txt"), Guid.NewGuid().ToString("N"));
+        RunGitCmd(repoPath, "add .");
+        RunGitCmd(repoPath, "commit -m local-change");
+        var localTip = RunGitOutput(repoPath, "rev-parse HEAD");
+        _ = CommitAndPush(sourcePath, "main");
+
+        var (success, error) = await GitService.PullFastForwardOnlyAsync(repoPath, TestContext.Current.CancellationToken).ConfigureAwait(false);
+
+        Assert.False(success);
+        Assert.NotNull(error);
+        Assert.NotEmpty(error);
+        Assert.Equal(localTip, RunGitOutput(repoPath, "rev-parse HEAD"));
+    }
+
+    [Fact]
+    public async Task PullFastForwardOnlyAsync_DirtyWorkingTree_ReturnsFailureWithError()
+    {
+        var (sourcePath, repoPath) = this.CreateRemoteBackedRepo();
+        var localTip = RunGitOutput(repoPath, "rev-parse HEAD");
+        CommitReadmeAndPush(sourcePath, "main");
+        File.AppendAllText(Path.Combine(repoPath, "README.md"), Environment.NewLine + "local dirty change");
+
+        var (success, error) = await GitService.PullFastForwardOnlyAsync(repoPath, TestContext.Current.CancellationToken).ConfigureAwait(false);
+
+        Assert.False(success);
+        Assert.NotNull(error);
+        Assert.NotEmpty(error);
+        Assert.Equal(localTip, RunGitOutput(repoPath, "rev-parse HEAD"));
+    }
+
+    [Fact]
+    public async Task PullFastForwardOnlyAsync_NoUpstream_ReturnsFailureWithError()
+    {
+        var repoPath = this.InitBareGitRepo();
+
+        var (success, error) = await GitService.PullFastForwardOnlyAsync(repoPath, TestContext.Current.CancellationToken).ConfigureAwait(false);
+
+        Assert.False(success);
+        Assert.NotNull(error);
+        Assert.NotEmpty(error);
+    }
+
+#pragma warning restore IDE1006
+
     private string InitBareGitRepo()
     {
         var repoPath = Path.Combine(this._tempDir, Path.GetRandomFileName());
@@ -598,6 +674,18 @@ public sealed class GitServiceTests : IDisposable
         File.WriteAllText(Path.Combine(sourcePath, "change-" + Guid.NewGuid().ToString("N") + ".txt"), Guid.NewGuid().ToString("N"));
         RunGitCmd(sourcePath, "add .");
         RunGitCmd(sourcePath, $"commit -m update-{branchName}");
+        RunGitCmd(sourcePath, $"push origin {branchName}");
+        var rev = RunGitOutput(sourcePath, $"rev-parse {branchName}");
+        RunGitCmd(sourcePath, "checkout main");
+        return rev;
+    }
+
+    private static string CommitReadmeAndPush(string sourcePath, string branchName)
+    {
+        RunGitCmd(sourcePath, $"checkout {branchName}");
+        File.AppendAllText(Path.Combine(sourcePath, "README.md"), Environment.NewLine + Guid.NewGuid().ToString("N"));
+        RunGitCmd(sourcePath, "add README.md");
+        RunGitCmd(sourcePath, $"commit -m update-readme-{branchName}");
         RunGitCmd(sourcePath, $"push origin {branchName}");
         var rev = RunGitOutput(sourcePath, $"rev-parse {branchName}");
         RunGitCmd(sourcePath, "checkout main");

--- a/tests/Services/WorkspaceCreationServiceTests.cs
+++ b/tests/Services/WorkspaceCreationServiceTests.cs
@@ -148,6 +148,37 @@ public sealed class WorkspaceCreationServiceTests : IDisposable
         Assert.Equal(localTip, RunGitOutput(repoPath, "rev-parse HEAD"));
     }
 
+    [Fact]
+    public async Task PullCurrentBranchAsync_AlreadyUpToDate_ReturnsSuccess()
+    {
+        var (_, repoPath) = this.CreateRemoteBackedRepo();
+        var localTip = RunGitOutput(repoPath, "rev-parse HEAD");
+
+        var (success, error) = await WorkspaceCreationService.PullCurrentBranchAsync(repoPath, TestContext.Current.CancellationToken).ConfigureAwait(false);
+
+        Assert.True(success, error);
+        Assert.Null(error);
+        Assert.Equal(localTip, RunGitOutput(repoPath, "rev-parse HEAD"));
+    }
+
+    [Fact]
+    public async Task PullCurrentBranchAsync_NonFastForward_ReturnsFailureWithError()
+    {
+        var (sourcePath, repoPath) = this.CreateRemoteBackedRepo();
+        CommitAndPush(sourcePath, "main");
+        File.WriteAllText(Path.Combine(repoPath, "local-change.txt"), Guid.NewGuid().ToString("N"));
+        RunGitCmd(repoPath, "add local-change.txt");
+        RunGitCmd(repoPath, "commit -m local-change");
+        var localTip = RunGitOutput(repoPath, "rev-parse HEAD");
+
+        var (success, error) = await WorkspaceCreationService.PullCurrentBranchAsync(repoPath, TestContext.Current.CancellationToken).ConfigureAwait(false);
+
+        Assert.False(success);
+        Assert.NotNull(error);
+        Assert.NotEmpty(error);
+        Assert.Equal(localTip, RunGitOutput(repoPath, "rev-parse HEAD"));
+    }
+
 #pragma warning restore IDE1006
 
     private string InitGitRepo()

--- a/tests/Services/WorkspaceCreationServiceTests.cs
+++ b/tests/Services/WorkspaceCreationServiceTests.cs
@@ -103,6 +103,53 @@ public sealed class WorkspaceCreationServiceTests : IDisposable
         Assert.Equal("origin/feature", effectiveSourceRef);
     }
 
+#pragma warning disable IDE1006
+
+    [Fact]
+    public async Task PullCurrentBranchAsync_HappyPath_AdvancesLocalToRemoteTip()
+    {
+        var (sourcePath, repoPath) = this.CreateRemoteBackedRepo();
+        var expected = CommitAndPush(sourcePath, "main");
+
+        var (success, error) = await WorkspaceCreationService.PullCurrentBranchAsync(repoPath, TestContext.Current.CancellationToken).ConfigureAwait(false);
+
+        Assert.True(success, error);
+        Assert.Null(error);
+        Assert.Equal(expected, RunGitOutput(repoPath, "rev-parse HEAD"));
+    }
+
+    [Fact]
+    public async Task PullCurrentBranchAsync_NoUpstream_FallsBackToFetchAndReturnsSuccess()
+    {
+        var (_, repoPath) = this.CreateRemoteBackedRepo();
+        RunGitCmd(repoPath, "checkout -b local-only");
+        var localTip = RunGitOutput(repoPath, "rev-parse HEAD");
+
+        var (success, error) = await WorkspaceCreationService.PullCurrentBranchAsync(repoPath, TestContext.Current.CancellationToken).ConfigureAwait(false);
+
+        Assert.True(success, error);
+        Assert.Null(error);
+        Assert.Equal(localTip, RunGitOutput(repoPath, "rev-parse HEAD"));
+    }
+
+    [Fact]
+    public async Task PullCurrentBranchAsync_DirtyWorkingTree_ReturnsFailureSurfacingGitError()
+    {
+        var (sourcePath, repoPath) = this.CreateRemoteBackedRepo();
+        var localTip = RunGitOutput(repoPath, "rev-parse HEAD");
+        CommitReadmeAndPush(sourcePath, "main");
+        File.AppendAllText(Path.Combine(repoPath, "README.md"), Environment.NewLine + "local dirty change");
+
+        var (success, error) = await WorkspaceCreationService.PullCurrentBranchAsync(repoPath, TestContext.Current.CancellationToken).ConfigureAwait(false);
+
+        Assert.False(success);
+        Assert.NotNull(error);
+        Assert.NotEmpty(error);
+        Assert.Equal(localTip, RunGitOutput(repoPath, "rev-parse HEAD"));
+    }
+
+#pragma warning restore IDE1006
+
     private string InitGitRepo()
     {
         var repoPath = Path.Combine(this._tempDir, Path.GetRandomFileName());
@@ -154,6 +201,18 @@ public sealed class WorkspaceCreationServiceTests : IDisposable
         File.WriteAllText(Path.Combine(sourcePath, "change-" + Guid.NewGuid().ToString("N") + ".txt"), Guid.NewGuid().ToString("N"));
         RunGitCmd(sourcePath, "add .");
         RunGitCmd(sourcePath, $"commit -m update-{branchName}");
+        RunGitCmd(sourcePath, $"push origin {branchName}");
+        var rev = RunGitOutput(sourcePath, $"rev-parse {branchName}");
+        RunGitCmd(sourcePath, "checkout main");
+        return rev;
+    }
+
+    private static string CommitReadmeAndPush(string sourcePath, string branchName)
+    {
+        RunGitCmd(sourcePath, $"checkout {branchName}");
+        File.AppendAllText(Path.Combine(sourcePath, "README.md"), Environment.NewLine + Guid.NewGuid().ToString("N"));
+        RunGitCmd(sourcePath, "add README.md");
+        RunGitCmd(sourcePath, $"commit -m update-readme-{branchName}");
         RunGitCmd(sourcePath, $"push origin {branchName}");
         var rev = RunGitOutput(sourcePath, $"rev-parse {branchName}");
         RunGitCmd(sourcePath, "checkout main");

--- a/tests/Services/WorkspaceCreationServiceTests.cs
+++ b/tests/Services/WorkspaceCreationServiceTests.cs
@@ -252,6 +252,7 @@ public sealed class WorkspaceCreationServiceTests : IDisposable
 
     private static string RunGitOutput(string workDir, string args)
     {
+        const int TimeoutMs = 10_000;
         var psi = new System.Diagnostics.ProcessStartInfo
         {
             FileName = "git",
@@ -263,13 +264,24 @@ public sealed class WorkspaceCreationServiceTests : IDisposable
             CreateNoWindow = true
         };
         using var proc = System.Diagnostics.Process.Start(psi) ?? throw new InvalidOperationException("Failed to start git.");
-        var stdout = proc.StandardOutput.ReadToEnd();
-        proc.WaitForExit(10_000);
+        var stdoutTask = proc.StandardOutput.ReadToEndAsync();
+        var stderrTask = proc.StandardError.ReadToEndAsync();
+        var exited = proc.WaitForExit(TimeoutMs);
+        if (!exited)
+        {
+            proc.Kill(entireProcessTree: true);
+        }
+
+        Assert.True(exited, $"git {args} timed out after {TimeoutMs}ms");
+        var stdout = stdoutTask.GetAwaiter().GetResult();
+        var stderr = stderrTask.GetAwaiter().GetResult();
+        Assert.True(proc.ExitCode == 0, $"git {args} failed: {stderr}");
         return stdout.Trim();
     }
 
     private static void RunGitCmd(string workDir, string args)
     {
+        const int TimeoutMs = 10_000;
         var psi = new System.Diagnostics.ProcessStartInfo
         {
             FileName = "git",
@@ -281,6 +293,17 @@ public sealed class WorkspaceCreationServiceTests : IDisposable
             CreateNoWindow = true
         };
         using var proc = System.Diagnostics.Process.Start(psi) ?? throw new InvalidOperationException("Failed to start git.");
-        proc.WaitForExit(10_000);
+        var stdoutTask = proc.StandardOutput.ReadToEndAsync();
+        var stderrTask = proc.StandardError.ReadToEndAsync();
+        var exited = proc.WaitForExit(TimeoutMs);
+        if (!exited)
+        {
+            proc.Kill(entireProcessTree: true);
+        }
+
+        Assert.True(exited, $"git {args} timed out after {TimeoutMs}ms");
+        _ = stdoutTask.GetAwaiter().GetResult();
+        var stderr = stderrTask.GetAwaiter().GetResult();
+        Assert.True(proc.ExitCode == 0, $"git {args} failed: {stderr}");
     }
 }


### PR DESCRIPTION
## Summary

Follow-up to PR #25. Roger reported that the **Same branch** mode of the *New Copilot Session* dialog was missing the `Update from upstream first` option. The original feature only exposed the checkbox in **Switch branch** and **New branch** modes. This PR closes that gap so users staying on the currently checked-out branch can also have it pulled to the latest before the session opens.

## What changed

* New service helpers in `GitService` and `WorkspaceCreationService`:
    * `GitService.PullFastForwardOnlyAsync(repoPath, ct)` runs `git pull --ff-only`.
    * `WorkspaceCreationService.PullCurrentBranchAsync(repoPath, ct)` resolves the current branch and its upstream remote, then either pulls or falls back to plain fetch when no upstream is configured.
    * The existing `UpdateSourceBranchAsync` is unchanged.
* `NewSessionNameVisuals` now shows the checkbox in Same branch mode and propagates the choice via `NewSessionResult.UpdateSourceFirst`.
* `MainForm.cs` and `MainForm.ContextMenu.cs` extract the update step out of the `Action != None` guard and route `BranchAction.None` to the new pull helper.
* `WorkspaceCreatorVisuals` is intentionally untouched. The worktree creator never targets the current checkout.

## How it behaves

| Scenario | Result |
|---|---|
| Same branch, checkbox on, upstream configured | `git pull --ff-only` runs, working tree advances to remote tip, session opens. |
| Same branch, checkbox on, dirty working tree | Pull fails, existing soft-fail prompt asks the user to continue with stale state or cancel. |
| Same branch, checkbox off | No fetch, no pull. |
| Same branch, no upstream | Falls back to `git fetch <remote>`. Returns success. |
| Switch / New branch | Existing `UpdateSourceBranchAsync` flow preserved. |
| PR / Issue | Checkbox hidden. PR refs are always fresh. |

## Tests

Pipeline ran the documented Squad workflow (`.squad/skills/workflow/SKILL.md`):

* **Lane 1** Architect (Neo) locked the API and wiring.
* **Lane 2 + 3** Tank wrote failing unit and integration tests covering Neo's five scenarios. Oracle approved test quality.
* **Lane 4** Trinity implemented to GREEN. Neo code-reviewed.
* **Lane 5** Morpheus wired the dialog and `MainForm` callsites. Oracle approved UI quality.
* **Lane 6** Tank added end-to-end coverage and renamed tests to the `MethodUnderTest_Scenario_ExpectedResult` convention. Oracle flagged legacy test git helpers that swallowed exit codes; Trinity hardened them per the lockout rule. Oracle re-approved. Morpheus signed off on the user experience.

Local validation gates (the Test workflow runs the same checks):

* `dotnet build --tl:off` clean, 0 warnings.
* Unit tests: 922 passed, 2 skipped, 0 failed.
* Integration tests: 131 passed, 21 skipped, 0 failed.
* `dotnet format copilot-booster.sln --verify-no-changes` clean.

## Open question for review

Per dialog checkbox state is NOT persisted back to `LauncherSettings.UpdateSourceBranchBeforeCreate`. Settings is the global default; the per-dialog checkbox is a one-off override. This matches the locked spec from the original interview Q3. If you want the dialog choice to become the new default, that is a one line follow-up.

## Out of scope

* Version bump.
* PR / Issue mode coverage. Those modes always fetch fresh refs already.